### PR TITLE
expose solutions in markdown cells rather that code cells

### DIFF
--- a/tutorial/Stark101-part1.ipynb
+++ b/tutorial/Stark101-part1.ipynb
@@ -33,9 +33,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from field import FieldElement\n",
@@ -66,22 +64,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution (click to the ... to unhide):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution (click to the arrow to unhide)</summary>\n",
+    "\n",
+    "```python\n",
     "a = [FieldElement(1), FieldElement(3141592)]\n",
     "while len(a) < 1023:\n",
-    "    a.append(a[-2] * a[-2] + a[-1] * a[-1])"
+    "    a.append(a[-2] * a[-2] + a[-1] * a[-1])\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -141,21 +132,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "g = FieldElement.generator() ** (3 * 2 ** 20)\n",
-    "G = [g ** i for i in range(1024)]"
+    "G = [g ** i for i in range(1024)]\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -261,21 +245,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "f = interpolate_poly(G[:-1], a)\n",
-    "v = f(2)"
+    "v = f(2)\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -328,23 +305,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "w = FieldElement.generator()\n",
     "h = w ** ((2 ** 30 * 3) // 8192)\n",
     "H = [h ** i for i in range(8192)]\n",
-    "eval_domain = [w * x for x in H]\n"
+    "eval_domain = [w * x for x in H]\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -357,9 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from hashlib import sha256\n",
@@ -396,21 +364,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "f = interpolate_poly(G[:-1], a)\n",
-    "f_eval = [f(d) for d in eval_domain]"
+    "f_eval = [f(d) for d in eval_domain]\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -510,7 +471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/tutorial/Stark101-part2.ipynb
+++ b/tutorial/Stark101-part2.ipynb
@@ -129,21 +129,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "numer0 = f - 1\n",
-    "denom0 = X - 1"
+    "denom0 = X - 1\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -173,9 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "numer0 % denom0"
@@ -237,22 +228,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "numer1 = f - 2338775057\n",
     "denom1 = X - g**1022\n",
-    "p1 = numer1 / denom1"
+    "p1 = numer1 / denom1\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -310,21 +294,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "lst = [(X - g**i) for i in range(1024)]\n",
-    "prod(lst)"
+    "prod(lst)\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -396,25 +373,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "numer2 = f(g**2 * X) - f(g * X)**2 - f**2\n",
     "print(\"Numerator at g^1020 is\", numer2(g**1020))\n",
     "print(\"Numerator at g^1021 is\", numer2(g**1021))\n",
     "denom2 = (X**1024 - 1) / ((X - g**1021) * (X - g**1022) * (X - g**1023))\n",
     "\n",
-    "p2 = numer2 / denom2"
+    "p2 = numer2 / denom2\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -427,9 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert p2.degree() == 1023, f'The degree of the third constraint is {p2.degree()} when it should be 1023.'\n",
@@ -490,24 +458,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def get_CP(channel):\n",
     "    alpha0 = channel.receive_random_field_element()\n",
     "    alpha1 = channel.receive_random_field_element()\n",
     "    alpha2 = channel.receive_random_field_element()\n",
-    "    return alpha0*p0 + alpha1*p1 + alpha2*p2"
+    "    return alpha0*p0 + alpha1*p1 + alpha2*p2\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -555,22 +516,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def CP_eval(channel):\n",
     "    CP = get_CP(channel)\n",
-    "    return [CP(d) for d in eval_domain]"
+    "    return [CP(d) for d in eval_domain]\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -595,22 +549,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "channel = Channel()\n",
     "CP_merkle = MerkleTree(CP_eval(channel))\n",
-    "channel.send(CP_merkle.root)"
+    "channel.send(CP_merkle.root)\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -647,7 +594,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/tutorial/Stark101-part3.ipynb
+++ b/tutorial/Stark101-part3.ipynb
@@ -123,21 +123,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def next_fri_domain(fri_domain):\n",
-    "    return [x ** 2 for x in fri_domain[:len(fri_domain) // 2]]"
+    "    return [x ** 2 for x in fri_domain[:len(fri_domain) // 2]]\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -210,25 +203,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def next_fri_polynomial(poly,  beta):\n",
     "    odd_coefficients = poly.poly[1::2]\n",
     "    even_coefficients = poly.poly[::2]\n",
     "    odd = beta * Polynomial(odd_coefficients)\n",
     "    even = Polynomial(even_coefficients)\n",
-    "    return odd + even"
+    "    return odd + even\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -275,24 +261,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def next_fri_layer(poly, domain, beta):\n",
     "    next_poly = next_fri_polynomial(poly, beta)\n",
     "    next_domain = next_fri_domain(domain)\n",
     "    next_layer = [next_poly(x) for x in next_domain]\n",
-    "    return next_poly, next_domain, next_layer"
+    "    return next_poly, next_domain, next_layer\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -372,19 +351,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def FriCommit(cp, domain, cp_eval, cp_merkle, channel):    \n",
     "    fri_polys = [cp]\n",
     "    fri_domains = [domain]\n",
@@ -399,7 +368,10 @@
     "        fri_merkles.append(MerkleTree(next_layer))\n",
     "        channel.send(fri_merkles[-1].root)   \n",
     "    channel.send(str(fri_polys[-1].poly[0]))\n",
-    "    return fri_polys, fri_domains, fri_layers, fri_merkles"
+    "    return fri_polys, fri_domains, fri_layers, fri_merkles\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -460,7 +432,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/tutorial/Stark101-part4.ipynb
+++ b/tutorial/Stark101-part4.ipynb
@@ -90,19 +90,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def decommit_on_fri_layers(idx, channel):\n",
     "    for layer, merkle in zip(fri_layers[:-1], fri_merkles[:-1]):\n",
     "        length = len(layer)\n",
@@ -112,7 +102,10 @@
     "        channel.send(str(merkle.get_authentication_path(idx)))\n",
     "        channel.send(str(layer[sib_idx]))\n",
     "        channel.send(str(merkle.get_authentication_path(sib_idx)))       \n",
-    "    channel.send(str(fri_layers[-1][0]))"
+    "    channel.send(str(fri_layers[-1][0]))\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -175,19 +168,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def decommit_on_query(idx, channel): \n",
     "    assert idx + 16 < len(f_eval), f'query index: {idx} is out of range. Length of layer: {len(f_eval)}.'\n",
     "    channel.send(str(f_eval[idx])) # f(x).\n",
@@ -196,7 +179,10 @@
     "    channel.send(str(f_merkle.get_authentication_path(idx + 8))) # auth path for f(gx).\n",
     "    channel.send(str(f_eval[idx + 16])) # f(g^2x).\n",
     "    channel.send(str(f_merkle.get_authentication_path(idx + 16))) # auth path for f(g^2x).\n",
-    "    decommit_on_fri_layers(idx, channel)    "
+    "    decommit_on_fri_layers(idx, channel)    \n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -246,23 +232,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Solution:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [],
-   "source": [
+    "<details><summary>Solution</summary>\n",
+    "\n",
+    "```python\n",
     "def decommit_fri(channel):\n",
     "    for query in range(3):\n",
     "        # Get a random index from the verifier and send the corresponding decommitment.\n",
-    "        decommit_on_query(channel.receive_random_int(0, 8191-16), channel)"
+    "        decommit_on_query(channel.receive_random_int(0, 8191-16), channel)\n",
+    "```\n",
+    "\n",
+    "</details>"
    ]
   },
   {
@@ -337,7 +316,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
hiya

I reckon this is relatively old stuff and that you have probably moved on, but:

while running this tuto recently, I found myself confused by the solution cells
having not realized they were code cells, I was happily running them without even realizing it

until I realized that the test cells were ALWAYS succeeding, which was suspicious
(being skilled is one thing, being invicible is another ;)

so, this version uses <details> in markdown cells to expose the solution but out of code
(in addition it's cool to be able to hide it again once you've taken a glimpse)


